### PR TITLE
Group 2 Feature: Dark mode and LocalStorage added

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-router": "^7.6.0",
         "react-router-dom": "^6.30.0"
       },
       "devDependencies": {
@@ -1602,6 +1603,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2474,18 +2484,25 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.0.tgz",
-      "integrity": "sha512-D3X8FyH9nBcTSHGdEKurK7r8OYE1kKFn3d/CF+CoxbSHkxU7o37+Uh7eAHRXr6k2tSExXYO++07PeXJtA/dEhQ==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.6.0.tgz",
+      "integrity": "sha512-GGufuHIVCJDbnIAXP3P9Sxzq3UUsddG3rrI3ut1q6m0FI6vxVBF3JoPQ38+W/blslLH4a5Yutp8drkEpXoddGQ==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.0"
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-router-dom": {
@@ -2503,6 +2520,21 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom/node_modules/react-router": {
+      "version": "6.30.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.0.tgz",
+      "integrity": "sha512-D3X8FyH9nBcTSHGdEKurK7r8OYE1kKFn3d/CF+CoxbSHkxU7o37+Uh7eAHRXr6k2tSExXYO++07PeXJtA/dEhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
       }
     },
     "node_modules/resolve-from": {
@@ -2570,6 +2602,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-router": "^7.6.0",
     "react-router-dom": "^6.30.0"
   },
   "devDependencies": {

--- a/src/components/app/App.jsx
+++ b/src/components/app/App.jsx
@@ -3,8 +3,42 @@ import Form from '../Form'
 import Home from '../Home'
 import TaskList from '../TaskList'
 import './App.css'
+import { useState, useEffect } from 'react'
 
 function App() {
+
+  const [mode, setMode] = useState((localStorage.getItem("modeState") === "true")); // localStorage stores everything as strings hence why true is in string data type
+
+  // console.log(`Mode is: ${mode}`)
+  // console.log(typeof mode)
+
+  function changeMode() {
+    setMode(mode => !mode);
+  }
+
+  useEffect(() => {
+    localStorage.setItem("modeState", mode); // const localStorage = { "modeState": mode}
+    if (mode) {
+      document.body.style.backgroundColor = "black";
+    } else {
+      document.body.style.backgroundColor = "white";
+    }
+  }, [mode])
+  // PLAN B
+
+  // const [darkMode, setDarkMode] = useState(false);
+
+  // const toggleDarkMode = () => {
+  //   setDarkMode(darkMode => !darkMode)
+  //   // if darkmode is false background color black 
+  //   if (darkMode) {
+  //     // JS to manipulate DOM
+  //     // Select element, change attribute
+  //     document.body.style.backgroundColor = "black";
+  //   } else {
+  //     document.body.style.backgroundColor = "#f9f9f9";
+  //   }
+  // }
 
   return (
     <>
@@ -16,10 +50,11 @@ function App() {
         </nav>
         <main className='app-main'>
           <Routes>
-            <Route path='/' element={ <Home/>} />
-            <Route path='/form' element={ <Form/>} />
-            <Route path='/tasks' element={ <TaskList/>} />
+            <Route path='/' element={<Home />} />
+            <Route path='/form' element={<Form />} />
+            <Route path='/tasks' element={<TaskList />} />
           </Routes>
+          <button onClick={changeMode}>Toggle Mode</button>
         </main>
       </div>
     </>


### PR DESCRIPTION
# 📦 Pull Request Template

## 📝 Description
Added usestate, useEffect and localStorage to the App.jsx to handle the light mode and dark mode changes

## 🔧 Setup & Testing Steps
_How can others test this feature locally?_

1. Pull this branch:
   ```bash
   git checkout -b group-2 origin/group-2
   ```
2. Install any new dependencies:
   ```bash
   npm install
   ```

3. Install React-router package:
  ``` bash
  npm install react-router
  ```

4. Run the development server:
   ```bash
   npm run dev
   ```
5. Navigate to the page/component you changed:
   > _Example: Go to `/home` and click on toggle mode button to change the mode from light to dark or vice versa._

6. Perform any manual testing needed:
   > _Example: Refresh web page and the mode will still persist

---

## 📸 Screenshots
_Include relevant screenshots or GIFs to show the UI changes or interactions._


> _Before:_
![Screenshot 2025-05-22 190600](https://github.com/user-attachments/assets/b2704e04-5353-4cb9-9b98-a51506dd813d)


> _After:_
![Screenshot 2025-05-22 190612](https://github.com/user-attachments/assets/77d55bb0-5934-4403-9c2e-7f517c8d4d99)

> _After_Reloading_Web_Page:
![Screenshot 2025-05-22 190612](https://github.com/user-attachments/assets/77d55bb0-5934-4403-9c2e-7f517c8d4d99)
---

## ✅ Checklist

- [ ] My changes follow the code style of this project
- [ ] I’ve tested the feature manually
- [ ] I’ve added screenshots to demonstrate changes (if applicable)
- [ ] I’ve checked that existing features aren’t broken
- [ ] I’ve rebased my branch onto `main`

---

> Tag your group and mention any reviewers who should look at this.

👥 Group: `Group #`
🔍 Reviewer(s): `@github-handle`

---

Happy Collaborating! 🎉